### PR TITLE
Add json-api serializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.1'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.7'
+gem 'jsonapi-serializer'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    jsonapi-serializer (2.1.0)
+      activesupport (>= 4.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -153,6 +155,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
+  jsonapi-serializer
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,1 @@
+## Why do we need this change?

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -6,7 +6,7 @@ class TopicsController < ApplicationController
 
   def show
     @topic = Topic.find(params[:id])
-    render json: TopicSerializer.new(@topic).serializable_hash, status: 201
+    render json: TopicSerializer.new(@topic).serializable_hash, status: 200
   end
 
   private

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,12 +1,12 @@
 class TopicsController < ApplicationController
   def index
     @topics = Topic.all
-    render json: @topics, status: 200
+    render json: TopicSerializer.new(@topics).serializable_hash, status: 200
   end
 
   def show
     @topic = Topic.find(params[:id])
-    render json: @topic, status: 201
+    render json: TopicSerializer.new(@topic).serializable_hash, status: 201
   end
 
   private

--- a/app/serializers/topic_serializer.rb
+++ b/app/serializers/topic_serializer.rb
@@ -1,0 +1,4 @@
+class TopicSerializer
+  include JSONAPI::Serializer
+  attributes :id, :title, :description, :questions
+end


### PR DESCRIPTION
### Why do we need this change?
We want to follow best practices and make our lives easier in the future.
Therefore we should follow the same pattern/format for sending resource data between client and a server.
Let's follow [this spec](https://jsonapi.org/format/)

![](https://media.giphy.com/media/elUGwgiPOdq7e/giphy.gif)
