### PR TITLE
Allow ember app to hit Topics controller methods

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -6,17 +6,46 @@ class TopicsController < ApplicationController
 
   def show
     @topic = Topic.find(params[:id])
+
     render json: TopicSerializer.new(@topic).serializable_hash, status: 200
+  end
+
+  def create
+    @topic = Topic.new(topic_params)
+    @topic.user_id = 1
+
+    if @topic.save
+      render json: TopicSerializer.new(@topic).serializable_hash, status: 201
+    else
+      render json: @topic.errors.details
+    end
+  end
+
+  def update
+    @topic = Topic.find(params[:id])
+
+    if @topic.update(topic_params)
+      render json: TopicSerializer.new(@topic).serializable_hash, status: 200
+    else
+      render json: topic.errors.details
+    end
+  end
+
+  def destroy
+    @topic = Topic.find(params[:id])
+    @topic.destroy
+
+    head :no_content
   end
 
   private
 
   def topic_params
-    params.require(:topic).permit(
-      :user_id,
+    params.require(:data).require(:attributes).permit(
       :title,
       :description,
       :questions
+      # :user_id,
     )
   end
 end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,3 +2,5 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+
+ Mime::Type.register "application/vnd.api+json", :json


### PR DESCRIPTION
Since we are using this Rails app as API only. There was an error
preventing the params to be access in the controller. The reason was
that due to the MIME type, the request was throwing a 500 error.

The fix was to register the type MIME `application/vnd.api+json` so that
`content_type` header has the correct type.

Another error preventing was the relationship constrain of `user_id`
unable to be `nil` for `topic.user_id` which was address in the
controller method `create`.

This was a temporary change for the `@topic.user_id = 1` which we will
change as soon as we are able to.

related:
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
* https://github.com/rails/rails/issues/28564

## Why do we need this change?
