### PR TITLE
Save user with password

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jsonapi-serializer'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+ gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    bcrypt (3.1.16)
     bootsnap (1.4.9)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -153,6 +154,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
   byebug
   jsonapi-serializer

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  has_secure_password
+
   validate :full_name
   validates_format_of :email, with: URI::MailTo::EMAIL_REGEXP
 

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,4 +1,4 @@
-class TopicSerializer
+class UserSerializer
   include JSONAPI::Serializer
   attributes :id, :email, :full_name
 end

--- a/db/migrate/20201029214854_create_users.rb
+++ b/db/migrate/20201029214854_create_users.rb
@@ -3,6 +3,7 @@ class CreateUsers < ActiveRecord::Migration[6.0]
     create_table :users do |t|
       t.string :full_name
       t.string :email
+      t.string :password_digest
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2020_10_29_220317) do
   create_table "users", force: :cascade do |t|
     t.string "full_name"
     t.string "email"
+    t.string "password_digest"
   end
 
   create_table "votes", force: :cascade do |t|


### PR DESCRIPTION
## Why do we need this change?
When westeros makes a post request with user attributes we need to save the email, and password.
Here we're using rails `has_secure_password` which requires bcrypt gem to be installed.
Now we can save user passing it `:email, :password, :password_confirmation` and it will hash the password and put it under `password_digest` column.