### PR TITLE
Reverse proxy westeros

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rails-reverse-proxy'
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'rails-reverse-proxy'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,9 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     public_suffix (4.0.6)
     puma (4.3.6)
       nio4r (~> 2.0)
@@ -175,6 +178,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry
+  pry-byebug
   puma (~> 4.1)
   rack-cors
   rails (~> 6.0.2, >= 6.0.2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     bcrypt (3.1.16)
     bootsnap (1.4.9)
       msgpack (~> 1.0)
@@ -96,11 +98,14 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    public_suffix (4.0.6)
     puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
+    rack-proxy (0.6.5)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.3.4)
@@ -123,6 +128,11 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-reverse-proxy (0.9.1)
+      addressable
+      rack
+      rack-proxy
+      rails
     railties (6.0.3.4)
       actionpack (= 6.0.3.4)
       activesupport (= 6.0.3.4)
@@ -168,6 +178,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rack-cors
   rails (~> 6.0.2, >= 6.0.2.2)
+  rails-reverse-proxy
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/app/controllers/westeros_controller.rb
+++ b/app/controllers/westeros_controller.rb
@@ -1,0 +1,7 @@
+class WesterosController < ApplicationController
+  include ReverseProxy::Controller
+
+  def index
+    reverse_proxy "http://localhost:4200"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,7 @@ Rails.application.routes.draw do
   resources :topics
   resources :responses
   resources :users, only: [:create]
+
   get "westeros/*all", to: "westeros#index"
+  get "assets/*all", to: "westeros#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   resources :topics
   resources :responses
   resources :users, only: [:create]
+  get "westeros/*all", to: "westeros#index"
 end


### PR DESCRIPTION
## Why do we need this change?
- reverse proxy requests: 
We want rails app to proxy request to ember server and back.
Any request that is made to `westeros/*all` or `assets/*all` 
will be directed to ember's node server that runs on port 4200

- installs pry-byebug: 
This is needed for commands like `next`, `step`, `continue` etc.