### PR TITLE
Backend User Authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
 class ApplicationController < ActionController::API
+  #for api only csrf token is not needed
+  #skip_before_action :verify_authenticity_token
 end

--- a/app/controllers/concerns/current_user_concern.rb
+++ b/app/controllers/concerns/current_user_concern.rb
@@ -1,0 +1,13 @@
+module CurrentUserConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_current_user
+  end
+
+  def set_current_user
+    if session[:user_id]
+      @current_user = User.find(session[:user_id])
+    end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,21 @@
+class SessionsController < ApplicationController
+  include ActionController::Cookies
+  include CurrentUserConcern
+
+  def create
+    user = User.find_by(email: params["email"]).try(:authenticate, params["password"])
+    if user
+      session[:user_id] = user.id
+      cookies[:logged_in] = { value: true, expires: 30.days }
+      render json: { status: :created, logged_in: true, user: UserSerializer.new(user) }
+    else
+      render json: { status: 401 }
+    end
+  end
+
+  def logout
+    reset_session
+    cookies[:logged_in] = { value: false }
+    render json: { status: 200, logged_out: true }
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,10 +1,21 @@
 class UsersController < ApplicationController
+  include CurrentUserConcern
+
   def create
     user = User.new(user_params)
     if user.save
+      session[:user_id] = user.id
       render json: UserSerializer.new(user).serializable_hash, status: 201
     else
       render json: user.errors.details
+    end
+  end
+
+  def index
+    if params[:me]
+      render json: UserSerializer.new(@current_user).serializable_hash, status: 200
+    else
+      render status: :unprocessable_entity
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
 
   validate :full_name
   validates_format_of :email, with: URI::MailTo::EMAIL_REGEXP
+  validates_presence_of :email
+  validates_uniqueness_of :email
 
   has_many :topics, foreign_key: :user_id
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,7 @@ module Tyrion
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore
   end
 end

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,0 +1,1 @@
+Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,10 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :topics
   resources :responses
-  resources :users, only: [:create]
+  resources :users, only: [:create, :index]
+  resources :sessions, only: [:create, :delete]
+
+  get :logout, to: "sessions#logout"
 
   get "westeros/*all", to: "westeros#index"
   get "assets/*all", to: "westeros#index"


### PR DESCRIPTION
## Why do we need this change?
This adds a few things to assist front-end with authentication:
- CurrentUserConcern
checks if user_id exists in the session (aka cookies) and finds the user that matches the id from cookie.
- SessionsController
when user clicks `login` on the fron-end, ember makese a request to `SessionsController#create`, finds the user based on username and password. If user exists we create a session (aka send back a cookie with user.user_id), then we also set another cookie manually with a boolean that just will tell the front-end if user was logged in successfully. 
Why do we set  the second cookie?
When we set the cookie with `session[:user_id] = user.id`, rails by fefault sets the cookie as HttpOnly which means javascript can't read the cookie on the front-end with `document.cookie` (this is done to avoid XSS attacks)
https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies
The second cookie is set manually without being HttpOnly, which means our front-end app can read it to find out if user is logged in, but if attacker steals this (non HttpOnly) cookie that's fine, because they still won't have access to the sensitive cookie that's used to identify the user.
- adds `index` method to UsersController
this endpoint will be hit to retrieve current user by Westeros. Westeros will send a request `users?me=true` and based on this we'll know to return the `@current_user`

