### PR TITLE
fix: search based on tickers only

### DIFF
--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -5,11 +5,10 @@ class Stock < ApplicationRecord
 
   #https://pganalyze.com/blog/full-text-search-ruby-rails-postgres
   pg_search_scope :search,
-                  against: { ticker: 'A', name: 'B' },
+                  against: :ticker,
                   using: { 
-                    tsearch: { prefix: true, dictionary: 'english', tsvector_column: 'searchable' } 
+                    tsearch: { prefix: true, dictionary: 'simple', tsvector_column: 'searchable' } 
                   }
-
 
   has_many :stock_transactions
   has_many :users, through: :stock_transactions

--- a/db/migrate/20201217160533_create_stocks.rb
+++ b/db/migrate/20201217160533_create_stocks.rb
@@ -14,8 +14,7 @@ class CreateStocks < ActiveRecord::Migration[6.0]
     execute <<-SQL
       ALTER TABLE stocks
       ADD COLUMN searchable tsvector GENERATED ALWAYS AS (
-        setweight(to_tsvector('english', coalesce(ticker, '')), 'A') ||
-        setweight(to_tsvector('english', coalesce(name,'')), 'B')
+        to_tsvector('simple', coalesce(ticker, ''))
       ) STORED;
     SQL
 

--- a/lib/tasks/load_stocks.rake
+++ b/lib/tasks/load_stocks.rake
@@ -6,4 +6,5 @@ task load_stocks: :environment do
   table.each do |stock|
     Stock.create({ ticker: stock[0], name: stock[1]})
   end
+  puts "Stocks loaded"
 end


### PR DESCRIPTION
## Why do we need this change?
Certain searches were coming back with less relevant results.
We should only search based on ticker name since this is more accurate and most people will be typing ticker names anyway. We can add searches based on names as well in V2 if needed.

![](https://media.giphy.com/media/l396Zo8GDwnzb4Xle/giphy.gif)