### PR TITLE
fix: add handler for user declining to login with reddit

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,6 +20,10 @@ class SessionsController < ApplicationController
     render json: { status: 200, logged_out: true }
   end
 
+  def redirect_on_error
+    redirect_to "/westeros/top-stocks"
+  end
+
   def session_params
     auth = request.env["omniauth.auth"]
     params = auth.slice("provider", "uid", "name")

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,5 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :reddit, ENV['REDDIT_ID'], ENV['REDDIT_SECRET'], { provider_ignores_state: true, scope: "identity"}
 end
+
+OmniAuth.config.on_failure = SessionsController.action(:redirect_on_error)


### PR DESCRIPTION
## Why do we need this change?
What happens if user **DECLINES** to login with Reddit, we need to handle this by redirecting the user to top-stocks page.

<img width="931" alt="Screen Shot 2021-01-02 at 6 22 21 PM" src="https://user-images.githubusercontent.com/14929384/103468485-76600680-4d27-11eb-8fa0-81be91572b7a.png">
