### PR TITLE
chore: return spacs in descending order

### DIFF
--- a/app/controllers/spacs_controller.rb
+++ b/app/controllers/spacs_controller.rb
@@ -1,6 +1,6 @@
 class SpacsController < ApplicationController
   def index
-    spacs = Spac.all
+    spacs = Spac.all.order('definitive_agreement desc')
     render json: SpacSerializer.new(spacs).serializable_hash, status: 200
   end
 


### PR DESCRIPTION
## Why do we need this change?
We want to show spacs starting with the most recent DA date first.