### PR TITLE
Return front end application based on environment

### DIFF
--- a/app/controllers/westeros_controller.rb
+++ b/app/controllers/westeros_controller.rb
@@ -1,7 +1,16 @@
-class WesterosController < ApplicationController
-  include ReverseProxy::Controller
+require 'open-uri'
+
+class WesterosController < ActionController::Base
+  include ActionView::Layouts
+  include ActionController::Rendering
+  include ReverseProxy::Controller if Rails.env.development?
 
   def index
-    reverse_proxy "http://localhost:4200"
+    if Rails.env.production?
+      url_response = URI.open(ENV['S3_EMBER_APP']).read
+      render html: url_response.html_safe
+    else
+      reverse_proxy 'http://localhost:4200'
+    end
   end
 end


### PR DESCRIPTION
We need to deploy the front end application from the Rails app to avoid
CORS issues. If the app is running on development we use reverse_proxy
to redirect to localhost:4200.

If the production application is running, we use the URI library to make
a request to the S3 endpoint, return the ember app and render it. Thus,
avoiding CORS issues

## Why do we need this change?
