### PR TITLE
Redirect root path to top stocks page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  get '/', to: 'westeros#index'
+  get '/westeros', to: 'westeros#index'
+
   resources :users, only: [:create, :index]
   resources :sessions, only: [:create, :delete]
   resources :stocks, only: [:index, :show, :update]


### PR DESCRIPTION
## Why do we need this change?
To redirect the root to the top-stocks page.