### PR TITLE
  Fix Bootsnap::CompileCache::PermissionError error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'dotenv-rails'
 # gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.4.2', require: false
+gem 'bootsnap', '~> 1.7', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     bcrypt (3.1.16)
-    bootsnap (1.5.1)
+    bootsnap (1.7.0)
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
@@ -109,7 +109,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.2)
     mixpanel-ruby (2.2.2)
-    msgpack (1.3.3)
+    msgpack (1.4.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -212,7 +212,7 @@ PLATFORMS
 
 DEPENDENCIES
   bcrypt (~> 3.1.7)
-  bootsnap (>= 1.4.2)
+  bootsnap (~> 1.7)
   byebug
   dotenv-rails
   jsonapi-serializer


### PR DESCRIPTION
## Why do we need this change?
To fix Bootsnap::CompileCache::PermissionError errors on production