### PR TITLE
feat: activate specific revision based on param

### DIFF
--- a/app/controllers/westeros_controller.rb
+++ b/app/controllers/westeros_controller.rb
@@ -7,7 +7,9 @@ class WesterosController < ActionController::Base
 
   def index
     if Rails.env.production?
-      url_response = URI.open(ENV['S3_EMBER_APP']).read
+      s3_url = ENV['S3_EMBER_APP'].dup
+      s3_url << ":#{params[:revision]}" if params[:revision]
+      url_response = URI.open(s3_url).read
       render html: url_response.html_safe
     else
       reverse_proxy 'http://localhost:4200'


### PR DESCRIPTION
## Why do we need this change?
We want to be able to activate specific version of our app and test it in production env before enabling it for all users.
If need be we can even add `split testing`.

#### What is split testing?
Split testing, commonly referred to as A/B testing, allows to compare two different versions of a web app — a control (the original) and variation — to determine which performs better. 

![](https://media.giphy.com/media/l0K461PvDhmsgiAHm/giphy.gif)